### PR TITLE
Use the baseName for query, file and form parameters, if not the REST…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
@@ -100,17 +100,17 @@ class {{controllerName}} extends Controller
 
         // Read out all input parameter values into variables
         {{#queryParams}}
-        ${{paramName}} = $request->query->get('{{paramName}}');
+        ${{paramName}} = $request->query->get('{{baseName}}');
         {{/queryParams}}
         {{#headerParams}}
         ${{paramName}} = $request->headers->get('{{baseName}}');
         {{/headerParams}}
         {{#formParams}}
         {{#isFile}}
-        ${{paramName}} = $request->files->get('{{paramName}}');
+        ${{paramName}} = $request->files->get('{{baseName}}');
         {{/isFile}}
         {{^isFile}}
-        ${{paramName}} = $request->request->get('{{paramName}}');
+        ${{paramName}} = $request->request->get('{{baseName}}');
         {{/isFile}}
         {{/formParams}}
         {{#bodyParams}}

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/git_push.sh
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/git_push.sh
@@ -36,7 +36,7 @@ git_remote=`git remote`
 if [ "$git_remote" = "" ]; then # git remote not defined
 
     if [ "$GIT_TOKEN" = "" ]; then
-        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git credential in your environment."
         git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
     else
         git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -121,7 +121,8 @@ class FakeApi
                 throw new ApiException(
                     "[{$e->getCode()}] {$e->getMessage()}",
                     $e->getCode(),
-                    $e->getResponse() ? $e->getResponse()->getHeaders() : null
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse()->getBody()->getContents()
                 );
             }
 

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/phpunit.xml.dist
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/phpunit.xml.dist
@@ -14,8 +14,8 @@
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./lib/Api</directory>
-            <directory suffix=".php">./lib/Model</directory>
+            <directory suffix=".php">./lib\Api</directory>
+            <directory suffix=".php">./lib\Model</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
… call will not be understood by server

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Symfony generation uses paramName instead of baseName for query, file and request parameters, which does not work with most of the client generation (at least not with the PHP) and is not compatible with the REST definition

