### PR TITLE
Return raw input data if no JMS format was matched

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -28,11 +28,16 @@ class JmsSerializer implements SerializerInterface
     public function deserialize($data, $type, $format)
     {
         if ($format == 'string') {
-            return $this->deserializeString($data, $type);           
+            return $this->deserializeString($data, $type);
+        }
+
+        // No format for deserialization with JMS serializer found, return raw data.
+        if (!$deserializationFormat = $this->convertFormat($format)) {
+            return $data;
         }
 
         // If we end up here, let JMS serializer handle the deserialization
-        return $this->serializer->deserialize($data, $type, $this->convertFormat($format));
+        return $this->serializer->deserialize($data, $type, $deserializationFormat);
     }
 
     private function convertFormat($format)


### PR DESCRIPTION
The `deserialize`method changes the incoming request data. We already introduced a special handling for format "string", and pass more complex data to the JMS deserializer, which can handle JSON and XML. Both is find in our normal requests, but we not intruduce file uploads via REST, so the incoming type would be "string", but the format will be "binary" - based on the Swagger spec. So we neither go into the "string" case, nor the later JMS mapping will match to JSON or XML and the request will fail.
This PR changes the handling of input before passing it to JMS, so we return the incoming data as-is to the API endpoints, if it's not a format JMS can handle.