### PR TITLE
SWPROD-1944 change response format in case of HttpError

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/Controller.mustache
@@ -137,14 +137,11 @@ class Controller
      */
     protected function serialize($data, $format)
     {
-        //Do not try and serialize binary formats
-        if(!in_array($format, $this->binaryFormats)){
-            return $this->serializer->serialize($data, $format);
-        }
-        else{
-            //If binary return is as is
+        if (in_array($format, $this->binaryFormats)) {
             return $data;
         }
+
+        return $this->serializer->serialize($data, $format);
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
@@ -161,6 +161,10 @@ class {{controllerName}} extends Controller
             $responseHeaders = [];
             $result = $handler->{{operationId}}({{#allParams}}${{paramName}}, {{/allParams}}$responseCode, $responseHeaders);
 
+            if ($result instanceof HttpError) {
+                $responseFormat = 'application/json';
+            }
+
             // Find default response message
             $message = '{{#responses}}{{#isDefault}}{{message}}{{/isDefault}}{{/responses}}';
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

