### PR TITLE
Feature/swprod 2118 make datetime independent from jms serializer version

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
@@ -37,7 +37,7 @@
     {{/isDate}}
     {{#isDateTime}}
      * @Assert\DateTime()
-     * @Type("DateTime")
+     * @Type("DateTime<'Y-m-d\TH:i:sO'>")
     {{/isDateTime}}
     {{^isDate}}
     {{^isDateTime}}


### PR DESCRIPTION
use always the same date-time format, independent from JMS serializer version

