### PR TITLE
Feature/swprod 2118 make datetime independent from jms serializer version

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
@@ -37,7 +37,7 @@
     {{/isDate}}
     {{#isDateTime}}
      * @Assert\DateTime()
-     * @Type("DateTime<'Y-m-d\TH:i:sO'>")
+     * @Type("DateTime")
     {{/isDateTime}}
     {{^isDate}}
     {{^isDateTime}}

--- a/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/model_variables.mustache
@@ -37,7 +37,7 @@
     {{/isDate}}
     {{#isDateTime}}
      * @Assert\DateTime()
-     * @Type("DateTime")
+     * @Type("DateTime<'Y-m-d\TH:i:sO'>")
     {{/isDateTime}}
     {{^isDate}}
     {{^isDateTime}}

--- a/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -22,14 +22,25 @@ class JmsSerializer implements SerializerInterface
             $builder
                 ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor($naming_strategy))
                 ->setDeserializationVisitor('xml', new XmlDeserializationVisitor($naming_strategy));
+        } else {
+            // JMS Serializer >=2.x
+            $builder->configureHandlers(
+                function (HandlerRegistry $registry) {
+                    $registry->registerSubscribingHandler(new DateHandler('Y-m-d\TH:i:sO'));
+                    $registry->registerSubscribingHandler(new StdClassHandler());
+                    $registry->registerSubscribingHandler(new ArrayCollectionHandler());
+                    $registry->registerSubscribingHandler(new \JMS\Serializer\Handler\IteratorHandler());
+                }
+            );
         }
 
         $this->serializer = $builder->build();
     }
 
+
     public function serialize($data, $format)
     {
-        return SerializerBuilder::create()->build()->serialize($data, $this->convertFormat($format));
+        return $this->serializer->serialize($data, $this->convertFormat($format));
     }
 
     public function deserialize($data, $type, $format)


### PR DESCRIPTION

SWPROD-2118 always use same date-time format independent from JMS serializer version